### PR TITLE
feat: fix php 8.4 type safety warning

### DIFF
--- a/config/spy.php
+++ b/config/spy.php
@@ -2,7 +2,7 @@
 
 return [
     'table_name' => 'http_logs',
-    
+
     'enabled' => env('SPY_ENABLED', true),
     'db_connection' => env('SPY_DB_CONNECTION'),
 

--- a/config/spy.php
+++ b/config/spy.php
@@ -1,10 +1,11 @@
 <?php
 
 return [
+    'table_name' => 'http_logs',
+    
     'enabled' => env('SPY_ENABLED', true),
     'db_connection' => env('SPY_DB_CONNECTION'),
-    'table_name' => 'http_logs',
 
-    'exclude_urls' => explode(',', env('SPY_EXCLUDE_URLS', null)),
+    'exclude_urls' => explode(',', env('SPY_EXCLUDE_URLS', '')),
     'obfuscates' => explode(',', env('SPY_OBFUSCATES', 'password')),
 ];


### PR DESCRIPTION
feat: fix php8.4 deprecation warning on passing null to explode() function parameter #2 which expected string

`explode(',', env('SPY_EXCLUDE_URLS', null))` // has deprecation warning with php8.4
`explode(',', env('SPY_EXCLUDE_URLS', ''))` // is OK with php8.4