### PR TITLE
Updating the handling of obfuscation mask

### DIFF
--- a/config/spy.php
+++ b/config/spy.php
@@ -29,7 +29,7 @@ return [
     /*
     * A mask string used to obfuscate fields in the logs.
     */
-    'obfuscation_mask' => env('SPY_OBFUSCATION_MASK'),
+    'obfuscation_mask' => env('SPY_OBFUSCATION_MASK', '🫣'),
 
     /*
     * Number of days to retain logs before cleaning.


### PR DESCRIPTION
Optionally pulling the mask string from config when the mask input hasn't explicitly been set to a string.

Reasoning: Some database charsets/collations may not be able to support the default of '🫣'.

This allows the implementation to avoid errors such as:  

> SQLSTATE[HY000]: General error: 3988 Conversion from collation utf8mb3_unicode_ci into utf8mb4_bin impossible for parameter