### PR TITLE
Fixed an error and added Context tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This package is useful for debugging, monitoring, and auditing external API call
 - Tracks all outgoing HTTP requests made via Laravel's HTTP client.
 - Logs request details, including URL, method, headers, payload, and response.
 - Configurable logging options to customize and obfuscate sensitive data.
+- Adds HttpLog ID to the application Context for use with error tracking 
 
 ## Requirements
 

--- a/database/migrations/create_spy_http_logs_table.php.stub
+++ b/database/migrations/create_spy_http_logs_table.php.stub
@@ -10,7 +10,7 @@ return new class extends Migration {
         Schema::connection(config('spy.connection'))
             ->create(config('spy.table_name'), function (Blueprint $table) {
                 $table->id();
-                $table->string('url', 2048)->index();
+                $table->string('url')->index();
                 $table->string('method', 6)->index();
                 $table->json('request_headers')->nullable();
                 $table->json('request_body')->nullable();

--- a/src/LaravelSpy.php
+++ b/src/LaravelSpy.php
@@ -4,6 +4,7 @@ namespace Farayaz\LaravelSpy;
 
 use Exception;
 use Farayaz\LaravelSpy\Models\HttpLog;
+use Illuminate\Support\Facades\Context;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Str;
 use Psr\Http\Message\RequestInterface;
@@ -20,6 +21,10 @@ class LaravelSpy
                 }
 
                 $httpLog = self::shouldLog($request) ? self::handleRequest($request) : null;
+
+                if ($httpLog) {
+                    Context::add('http_log_id', $httpLog->getKey());
+                }
 
                 $responsePromise = $handler($request, $options);
 

--- a/tests/Feature/HttpLoggingTest.php
+++ b/tests/Feature/HttpLoggingTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 use Farayaz\LaravelSpy\Models\HttpLog;
+use Illuminate\Support\Facades\Context;
 use Illuminate\Support\Facades\Http;
 use Tests\TestCase;
 
@@ -51,6 +52,24 @@ class HttpLoggingTest extends TestCase
         $log = HttpLog::first();
         $this->assertEquals(['name' => 'John', 'email' => 'john@example.com'], $log->request_body);
         $this->assertEquals(['id' => 1, 'name' => 'John'], $log->response_body);
+    }
+
+    /** @test */
+    public function it_adds_http_log_id_to_context()
+    {
+        Http::fake([
+            'https://api.example.com/users' => Http::response(['id' => 1, 'name' => 'John'], 201, ['Content-Type' => 'application/json'])
+        ]);
+
+        Http::post('https://api.example.com/users', [
+            'name' => 'John',
+            'email' => 'john@example.com'
+        ]);
+
+        $log = HttpLog::first();
+
+        $this->assertTrue(Context::has('http_log_id'));
+        $this->assertEquals(Context::get('http_log_id'), $log->id);
     }
 
     /** @test */


### PR DESCRIPTION
Hello,

When installing this package, I encountered the following error during the migration step:

```
   INFO  Running migrations.  

  2025_09_01_140544_create_spy_http_logs_table ........................................................................................ 12.37ms FAIL

   Illuminate\Database\QueryException 

  SQLSTATE[42000]: Syntax error or access violation: 1071 Specified key was too long; max key length is 3072 bytes (Connection: mysql, SQL: alter table `http_logs` add index `http_logs_url_index`(`url`))

  at vendor/laravel/framework/src/Illuminate/Database/Connection.php:824
    820▕                     $this->getName(), $query, $this->prepareBindings($bindings), $e
    821▕                 );
    822▕             }
    823▕ 
  ➜ 824▕             throw new QueryException(
    825▕                 $this->getName(), $query, $this->prepareBindings($bindings), $e
    826▕             );
    827▕         }
    828▕     }

      +8 vendor frames 

  9   database/migrations/2025_09_01_140544_create_spy_http_logs_table.php:11
      Illuminate\Database\Schema\Builder::create("http_logs", Object(Closure))
      +26 vendor frames 

  36  artisan:16
      Illuminate\Foundation\Application::handleCommand(Object(Symfony\Component\Console\Input\ArgvInput))

```
I removed the string length restriction on the migration file to get around this.

Additionally, I wanted to be able to track the HTTP log ID within Laravel’s context. This can be useful for tools like Sentry, which automatically extract context data and include it in error reports. By adding the log ID to the context, it becomes much easier to trace and debug issues based on request/response pairs.

https://laravel.com/docs/12.x/context

I wrote tests.

I hope this is useful!